### PR TITLE
Observability 01

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/sys v0.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/internal/observability/http.go
+++ b/internal/observability/http.go
@@ -1,0 +1,55 @@
+package observability
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Middleware holds configuration for HTTP Observability
+type Middleware struct {
+	TraceIdHeader string
+}
+
+// Wrap returns an Handler that add Observability to http Request Context and call next.
+func (self Middleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t0 := time.Now()
+
+		var tId string
+		if "" != self.TraceIdHeader {
+			tId = r.Header.Get(self.TraceIdHeader)
+		}
+		if "" == tId {
+			tId = uuid.New().String()
+		}
+
+		log := GetObservability(r.Context()).Log().With("tId", tId)
+		obs := Observability{Logger: log}
+		ctx := SetObservability(r.Context(), &obs)
+		sw := statusRecorder{ResponseWriter: w}
+		next.ServeHTTP(&sw, r.Clone(ctx))
+		log.Info(
+			"processed HTTP request",
+			"method", r.Method,
+			"host", r.Host,
+			"uri", r.RequestURI,
+			"status", sw.status,
+			"duration", time.Since(t0),
+		)
+
+	})
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (self *statusRecorder) WriteHeader(statusCode int) {
+	self.status = statusCode
+	self.ResponseWriter.WriteHeader(statusCode)
+}
+
+var _ http.ResponseWriter = &statusRecorder{}

--- a/internal/observability/log.go
+++ b/internal/observability/log.go
@@ -1,0 +1,19 @@
+package observability
+
+import (
+	"io"
+	"log/slog"
+	"math"
+)
+
+var noopLogger *slog.Logger
+
+// NoopLogger returns a disabled Logger
+func NoopLogger() *slog.Logger {
+	return noopLogger
+}
+
+func init() {
+	hdlr := slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.Level(math.MaxInt)})
+	noopLogger = slog.New(hdlr)
+}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -1,0 +1,39 @@
+package observability
+
+import (
+	"context"
+	"log/slog"
+)
+
+type contextKey string
+
+const (
+	observabilityKey = contextKey("OBSERVABILITY")
+)
+
+// Observability holds Loggers & Metrics.
+// nil *Observability are safe to use.
+type Observability struct {
+	Logger *slog.Logger
+}
+
+// Log returns inner Logger or slog.Default().
+func (self *Observability) Log() *slog.Logger {
+	if (nil == self) || (nil == self.Logger) {
+		return slog.Default()
+	}
+
+	return self.Logger
+}
+
+// GetObservability returns ctx Observability.
+func GetObservability(ctx context.Context) *Observability {
+	var rv *Observability
+	rv, _ = ctx.Value(observabilityKey).(*Observability)
+	return rv
+}
+
+// SetObservability returns new Context containing obs.
+func SetObservability(ctx context.Context, obs *Observability) context.Context {
+	return context.WithValue(ctx, observabilityKey, obs)
+}

--- a/internal/observability/utils.go
+++ b/internal/observability/utils.go
@@ -1,0 +1,18 @@
+package observability
+
+import (
+	"log/slog"
+	"testing"
+)
+
+// SetTestDebugLogging assigns DEBUG level to slog Default logger for test duration
+func SetTestDebugLogging(t *testing.T) {
+	oldLevel := slog.SetLogLoggerLevel(slog.LevelDebug)
+	if oldLevel != slog.LevelDebug {
+		t.Logf("Setting slog level to %s", slog.LevelDebug)
+		t.Cleanup(func() {
+			t.Logf("Restoring slog level to %s", oldLevel)
+			slog.SetLogLoggerLevel(oldLevel)
+		})
+	}
+}

--- a/internal/protocols/enroll/client.go
+++ b/internal/protocols/enroll/client.go
@@ -2,10 +2,12 @@ package enroll
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdh"
 	"crypto/rand"
 
 	"code.kerpass.org/golang/internal/credentials"
+	"code.kerpass.org/golang/internal/observability"
 	"code.kerpass.org/golang/internal/protocols"
 	"code.kerpass.org/golang/pkg/noise"
 )
@@ -84,17 +86,25 @@ var _ protocols.Fsm[*ClientState] = &ClientState{}
 
 // State functions
 
-func ClientInit(self *ClientState, _ []byte) (sf ClientStateFunc, rmsg []byte, err error) {
+func ClientInit(ctx context.Context, self *ClientState, _ []byte) (sf ClientStateFunc, rmsg []byte, err error) {
 	sf = ClientInit
+	var errmsg string
+
+	// get logger
+	log := observability.GetObservability(ctx).Log().With("state", "ClientInit")
 
 	// create a Static Keypair
+	log.Debug("generating Card Keypair")
 	curve := noiseCfg.CurveAlgo
 	keypair, err := curve.GenerateKey(rand.Reader)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed generating Card Keypair")
+		errmsg = "failed generating Card Keypair"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 
 	// initialize noise Handshake
+	log.Debug("initializing noise handshake")
 	params := noise.HandshakeParams{
 		Cfg:           noiseCfg,
 		Prologue:      self.RealmId,
@@ -104,92 +114,136 @@ func ClientInit(self *ClientState, _ []byte) (sf ClientStateFunc, rmsg []byte, e
 	}
 	err = self.hs.Initialize(params)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed hs.Initialize")
+		errmsg = "failed initializing noise handshake"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 
 	// generate initial noise msg
 	// Client: -> e
+	log.Debug("generating handshake message with nil payload")
 	var buf bytes.Buffer
 	_, err = self.hs.WriteMessage(nil, &buf)
+	if nil != err {
+		errmsg = "failed generating handshake message"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
+
+	}
 
 	// prepare Client: -> [EnrollReq]
 	// It can not be send as noise payload because the server needs to know the RealmId to load its static key...
+	log.Debug("preparing EnrollReq message")
 	req := EnrollReq{RealmId: self.RealmId, Msg: buf.Bytes()}
 	rmsg, err = cborSrz.Marshal(req)
 	if nil != err {
-		return sf, nil, wrapError(err, "failed serializing the initial EnrollReq message")
+		errmsg = "failed CBOR marshal of EnrollReq"
+		log.Debug(errmsg, "error", err)
+		return sf, nil, wrapError(err, errmsg)
 	}
 
+	log.Debug("OK, switching to ClientReceiveServerKey state")
 	return ClientReceiveServerKey, rmsg, nil
 }
 
-func ClientReceiveServerKey(self *ClientState, msg []byte) (sf ClientStateFunc, rmsg []byte, err error) {
+func ClientReceiveServerKey(ctx context.Context, self *ClientState, msg []byte) (sf ClientStateFunc, rmsg []byte, err error) {
 	sf = ClientReceiveServerKey
+	var errmsg string
+
+	// get logger
+	log := observability.GetObservability(ctx).Log().With("state", "ClientReceiveServerKey")
 
 	// schedule recovering inner noise HandshakeState in case of error...
 	hsbkup := self.hs
 	defer func() {
 		if nil != err {
+			log.Debug("restoring initial handshake state following error")
 			self.hs = hsbkup
 		}
 	}()
 
 	// receive Server: <- e, ee, s, es, {Certificate}
+	log.Debug("reading handshake message")
 	var buf bytes.Buffer
 	_, err = self.hs.ReadMessage(msg, &buf)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed noise handshake ReadMessage")
+		errmsg = "failed reading handshake message"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 	srvcert := buf.Bytes()
 
 	// control RemoteStaticKey()
+	log.Debug("controlling remote server static key")
 	srvkey := self.hs.RemoteStaticKey()
 	err = pkiCheck(srvkey, srvcert)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed server Static Key control")
+		errmsg = "failed remote server static key control"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 
 	// prepare Client: -> s, se, {EnrollAuthorization}
+	log.Debug("generating handshake message with EnrollAuthorization payload")
 	srzmsg, err := cborSrz.Marshal(EnrollAuthorization{AuthorizationId: self.AuthorizationId})
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed serializing the EnrollAuthorization message")
+		errmsg = "failed CBOR marshal of EnrollAuthorization"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 	buf.Reset()
 	_, err = self.hs.WriteMessage(srzmsg, &buf)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed noise handshake WriteMessage")
+		errmsg = "failed generating handshake message"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 
+	log.Debug("OK, switching to ClientCardCreate state")
 	return ClientCardCreate, buf.Bytes(), nil
 }
 
-func ClientCardCreate(self *ClientState, msg []byte) (sf ClientStateFunc, rmsg []byte, err error) {
+func ClientCardCreate(ctx context.Context, self *ClientState, msg []byte) (sf ClientStateFunc, rmsg []byte, err error) {
 	sf = ClientCardCreate
+	var errmsg string
+
+	// get logger
+	log := observability.GetObservability(ctx).Log().With("state", "ClientCardCreate")
 
 	// schedule recovering inner noise HandshakeState in case of error...
 	hsbkup := self.hs
 	defer func() {
-		if nil != err {
+		if protocols.IsError(err) {
+			log.Debug("restoring initial handshake state following error")
 			self.hs = hsbkup
 		}
 	}()
 
 	// receive Server: <- psk, {EnrollCardCreateResp}
+	log.Debug("reading handshake message")
 	var buf bytes.Buffer
 	_, err = self.hs.ReadMessage(msg, &buf)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed noise handshake ReadMessage")
+		errmsg = "failed reading handshake message"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
+	log.Debug("extracting EnrollCardCreateResp from handshake message payload")
 	srv := EnrollCardCreateResp{}
 	err = cborSrz.Unmarshal(buf.Bytes(), &srv)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed unmarshaling EnrollCardCreateResp")
+		errmsg = "failed CBOR unmarshal of EnrollCardCreateResp"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 
 	// create new Card
+	log.Debug("creating Card")
 	psk, err := derivePSK(self.RealmId, srv.CardId, self.hs.GetHandshakeHash())
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed deriving psk")
+		errmsg = "failed deriving Card psk"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 	card := credentials.Card{
 		RealmId: self.RealmId,
@@ -201,20 +255,27 @@ func ClientCardCreate(self *ClientState, msg []byte) (sf ClientStateFunc, rmsg [
 	card.Kh.PrivateKey = self.hs.StaticKeypair()
 
 	// save new Card
+	log.Debug("saving Card")
 	cardId, err := self.Repo.SaveCard(card)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed saving card")
+		errmsg = "failed saving card"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 	card.ID = cardId
 	self.cardId = cardId
 
 	// prepare Client: -> psk, {}
+	log.Debug("generating handshake message")
 	buf.Reset()
 	_, err = self.hs.WriteMessage(nil, &buf)
 	if nil != err {
-		return sf, rmsg, wrapError(err, "failed noise handshake WriteMessage")
+		errmsg = "failed generating handshake message"
+		log.Debug(errmsg, "error", err)
+		return sf, rmsg, wrapError(err, errmsg)
 	}
 
+	log.Debug("SUCCESS, completed enroll protocol")
 	return nil, buf.Bytes(), protocols.OK
 }
 

--- a/internal/protocols/enroll/enroll_test.go
+++ b/internal/protocols/enroll/enroll_test.go
@@ -1,6 +1,7 @@
 package enroll
 
 import (
+	"context"
 	"crypto/rand"
 	"net"
 	"testing"
@@ -9,9 +10,11 @@ import (
 	"code.kerpass.org/golang/internal/credentials"
 	"code.kerpass.org/golang/internal/protocols"
 	"code.kerpass.org/golang/internal/transport"
+	"code.kerpass.org/golang/internal/observability"
 )
 
 func TestFsmEnrollSuccess(t *testing.T) {
+	observability.SetTestDebugLogging(t)
 	cli, srv := makePeerState(t)
 
 	// create transports
@@ -25,14 +28,14 @@ func TestFsmEnrollSuccess(t *testing.T) {
 	// run client protocol
 	rc := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(cli, ct)
+		err := protocols.Run(context.Background(), cli, ct)
 		result <- err
 	}(rc)
 
 	// run server protocol
 	rs := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(srv, st)
+		err := protocols.Run(context.Background(), srv, st)
 		result <- err
 	}(rs)
 
@@ -66,6 +69,7 @@ func TestFsmEnrollSuccess(t *testing.T) {
 }
 
 func TestFsmEnrollFailAuthorization(t *testing.T) {
+	observability.SetTestDebugLogging(t)
 	cli, srv := makePeerState(t)
 
 	// change client authorization
@@ -82,14 +86,14 @@ func TestFsmEnrollFailAuthorization(t *testing.T) {
 	// run client protocol
 	rc := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(cli, ct)
+		err := protocols.Run(context.Background(), cli, ct)
 		result <- err
 	}(rc)
 
 	// run server protocol
 	rs := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(srv, st)
+		err := protocols.Run(context.Background(), srv, st)
 		result <- err
 	}(rs)
 
@@ -122,6 +126,7 @@ func TestFsmEnrollFailAuthorization(t *testing.T) {
 }
 
 func TestFsmEnrollFailReadClientConfirmation(t *testing.T) {
+	observability.SetTestDebugLogging(t)
 	cli, srv := makePeerState(t)
 
 	// create transports
@@ -140,14 +145,14 @@ func TestFsmEnrollFailReadClientConfirmation(t *testing.T) {
 	// run client protocol
 	rc := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(cli, ct)
+		err := protocols.Run(context.Background(), cli, ct)
 		result <- err
 	}(rc)
 
 	// run server protocol
 	rs := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(srv, st)
+		err := protocols.Run(context.Background(), srv, st)
 		result <- err
 	}(rs)
 
@@ -183,6 +188,7 @@ func TestFsmEnrollFailReadClientConfirmation(t *testing.T) {
 }
 
 func TestFsmEnrollFailWriteClientConfirmation(t *testing.T) {
+	observability.SetTestDebugLogging(t)
 	cli, srv := makePeerState(t)
 
 	// create transports
@@ -201,14 +207,14 @@ func TestFsmEnrollFailWriteClientConfirmation(t *testing.T) {
 	// run client protocol
 	rc := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(cli, ct)
+		err := protocols.Run(context.Background(), cli, ct)
 		result <- err
 	}(rc)
 
 	// run server protocol
 	rs := make(chan error, 1)
 	go func(result chan<- error) {
-		err := protocols.Run(srv, st)
+		err := protocols.Run(context.Background(), srv, st)
 		result <- err
 	}(rs)
 

--- a/internal/protocols/enroll/enroll_test.go
+++ b/internal/protocols/enroll/enroll_test.go
@@ -8,9 +8,9 @@ import (
 	"time"
 
 	"code.kerpass.org/golang/internal/credentials"
+	"code.kerpass.org/golang/internal/observability"
 	"code.kerpass.org/golang/internal/protocols"
 	"code.kerpass.org/golang/internal/transport"
-	"code.kerpass.org/golang/internal/observability"
 )
 
 func TestFsmEnrollSuccess(t *testing.T) {

--- a/internal/protocols/enroll/errors.go
+++ b/internal/protocols/enroll/errors.go
@@ -9,8 +9,9 @@ type errorFlag string
 
 const (
 	// All package errors are wrapping Error
-	Error   = errorFlag("enroll: error")
-	noError = errorFlag("")
+	Error                   = errorFlag("enroll: error")
+	ErrInvalidAuthorization = errorFlag("enroll: invalid authorization")
+	noError                 = errorFlag("")
 )
 
 // Error implements the error interface.

--- a/internal/protocols/enroll/http.go
+++ b/internal/protocols/enroll/http.go
@@ -93,7 +93,7 @@ func (self HttpHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var bkupState ServerState
 	state, sf := s.state.State()
 	bkupState = *state
-	sf, rmsg, err := sf(state, hm.Msg)
+	sf, rmsg, err := sf(r.Context(), state, hm.Msg)
 	defer func() {
 		if success {
 			s.state.SetState(sf)
@@ -199,7 +199,7 @@ func EnrollOverHTTP(ctx context.Context, cli httpClient, serverUrl string, cfg C
 	var resp *http.Response
 	var errProto, errIO error
 	for step := range 3 {
-		stateFunc, climsg, errProto = stateFunc(state, srvmsg)
+		stateFunc, climsg, errProto = stateFunc(ctx, state, srvmsg)
 		if nil == climsg {
 			break
 		}

--- a/internal/protocols/enroll/http_test.go
+++ b/internal/protocols/enroll/http_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,7 +16,7 @@ import (
 )
 
 func TestHttpEnrollSuccess(t *testing.T) {
-	setDebugLogging(t)
+	observability.SetTestDebugLogging(t)
 
 	clicfg, srvhdlr := makePeerConfig(t)
 
@@ -53,7 +52,7 @@ func TestHttpEnrollSuccess(t *testing.T) {
 }
 
 func TestHttpEnrollReplaySuccess(t *testing.T) {
-	// setDebugLogging(t)
+	observability.SetTestDebugLogging(t)
 
 	clicfg, srvhdlr := makePeerConfig(t)
 
@@ -192,12 +191,4 @@ func makePeerConfig(t *testing.T) (ClientCfg, HttpHandler) {
 	}
 
 	return cli, srv
-}
-
-func setDebugLogging(t *testing.T) {
-	oldLevel := slog.SetLogLoggerLevel(slog.LevelDebug)
-	t.Cleanup(func() {
-		t.Logf("Restoring slog level to %s", oldLevel)
-		slog.SetLogLoggerLevel(oldLevel)
-	})
 }

--- a/internal/protocols/errors.go
+++ b/internal/protocols/errors.go
@@ -6,7 +6,6 @@ import (
 	"code.kerpass.org/golang/internal/utils"
 )
 
-
 // errorFlag is a private error type that allows declaring error constants.
 type errorFlag string
 

--- a/internal/protocols/errors.go
+++ b/internal/protocols/errors.go
@@ -1,8 +1,11 @@
 package protocols
 
 import (
+	"errors"
+
 	"code.kerpass.org/golang/internal/utils"
 )
+
 
 // errorFlag is a private error type that allows declaring error constants.
 type errorFlag string
@@ -25,6 +28,11 @@ func (self errorFlag) Unwrap() error {
 	} else {
 		return Error
 	}
+}
+
+// IsError test if err is not protocols.OK
+func IsError(err error) bool {
+	return (nil != err) && !errors.Is(err, OK)
 }
 
 // newError returns a utils.RaisedErr{} that contains file & line of where it was called.


### PR DESCRIPTION
This PR starts the work for logs & metrics collection across the project.

It adds an `observability` package which define : 
* Observability struct that allows passing Logger & Metrics across Context
* HTTP Middleware to add Observability to request Context and log endpoint performance...

It modifies the `protocols` and `protocols/enroll` packages: 
* Add a Context parameter to protocols State functions.
* Add DEBUG logs to the enroll State machines.

